### PR TITLE
Valor pendente para ativar o efeito colateral no uso do hook useFetchMore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Pass the ordering type to the client-side, so that it activates the side effect in the `useFetchMore` hook
+
 ## [0.6.17] - 2020-02-20
 
 ## [0.6.16] - 2020-02-19

--- a/react/components/SearchQuery.js
+++ b/react/components/SearchQuery.js
@@ -91,7 +91,7 @@ const SearchQuery = ({
     withFacets: true,
     query: reject(isEmpty, ["search", attributePath]).join("/"),
     map: map || "s",
-    orderBy: "",
+    orderBy: order,
     from: 0,
     to: variables.count * variables.page - 1,
     facetQuery: "search",


### PR DESCRIPTION
In this PR:
- Pass the ordering type to the client-side, so that you activate the side effect in the `useFetchMore` hook. Because of having a dependency with this value.