### PR TITLE
Feature/add refetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix `refetch` function.
+
 ## [0.8.1] - 2020-03-17
 
 ### Added

--- a/react/utils/compatibility-layer.ts
+++ b/react/utils/compatibility-layer.ts
@@ -13,6 +13,13 @@ type FetchMoreOptions = {
   updateQuery: UpdateQuery;
 };
 type FetchMore = (options: FetchMoreOptions) => Promise<any>;
+type RefetchVariables = {
+  from: number;
+  to: number;
+  count: number;
+  page: number;
+};
+type Refetch = (options: Partial<RefetchVariables>) => Promise<any>;
 
 /**
  * Our Query depends on a `page` variable, but store-components' SearchContext
@@ -43,6 +50,27 @@ export const makeFetchMore = (
       },
     },
   );
+};
+
+/**
+ * Our Query depends on a `page` variable, but store-components' SearchContext
+ * works with `from` and `to` variables. This methods provides a layer when
+ * refetch is called to transform `from` and `to` into `page` and `count`.
+ *
+ * @param refetch Apollo's refetch function for our query.
+ */
+export const makeRefetch = (refetch: Refetch): Refetch => async variables => {
+  console.log("refetched");
+  const { from, to } = variables;
+  const hasPagination =
+    typeof from !== "undefined" && typeof to !== "undefined";
+
+  const count = hasPagination ? to! - from! + 1 : undefined;
+  const page = hasPagination
+    ? Math.round((to! + 1) / (to! - from!))
+    : undefined;
+
+  return await refetch({ ...variables, page, count });
 };
 
 /**

--- a/react/utils/compatibility-layer.ts
+++ b/react/utils/compatibility-layer.ts
@@ -60,7 +60,6 @@ export const makeFetchMore = (
  * @param refetch Apollo's refetch function for our query.
  */
 export const makeRefetch = (refetch: Refetch): Refetch => async variables => {
-  console.log("refetched");
   const { from, to } = variables;
   const hasPagination =
     typeof from !== "undefined" && typeof to !== "undefined";


### PR DESCRIPTION
A Exito costuma usar o `refetch` para completar a listagem de produtos, mas no momento eles estão usando o `fetchmore` já que o nosso `refetch` não estava funcionando corretamente.

Fiz o ajuste no `refetch` e agora é possível usa-lo