### PR TITLE
Feature/custom maximum suggested products by breakpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Custom maximum suggested products in autocomplete based on breakpoints.
+
 ## [0.7.2] - 2020-03-09
 
 ### Fixed

--- a/docs/Autocomplete.md
+++ b/docs/Autocomplete.md
@@ -30,16 +30,17 @@ Add `autocomplete-result-list.v2` into the blocks of a `search-bar`. We also rec
 
 ### Props
 
-| Prop name              | Type                                      | Description                                               | Default value |
-| ---------------------- | ----------------------------------------- | --------------------------------------------------------- | ------------- |
-| `maxTopSearches`       | `Number`                                  | Maximum number of terms in the top searches list          | `10`          |
-| `maxHistory`           | `Number`                                  | Maximum number of terms in the search history list        | `5`           |
-| `maxSuggestedProducts` | `Number`                                  | Maximum number of suggested products                      | `3`           |
-| `maxSuggestedTerms`    | `Number`                                  | Maximum number of suggested terms                         | `3`           |
-| `autocompleteWidth`    | `Number`                                  | Autocomplete width. Number between `0` and `100`          | -             |
-| `productLayout`        | [`ProductLayoutEnum`](#productlayoutenum) | Defines the product layout in the suggested products list | -             |
-| `hideTitles`           | `Boolean`                                 | If true, all the titles will be hidden                    | `false`       |
-| `historyFirst`         | `Boolean`                                 | If true, the history list will be prioritized             | `false`       |
+| Prop name              | Type                                              | Description                                                   | Default value |
+| ---------------------- | ------------------------------------------------- | ------------------------------------------------------------- | ------------- |
+| `maxTopSearches`       | `Number`                                          | Maximum number of terms in the top searches list              | `10`          |
+| `maxHistory`           | `Number`                                          | Maximum number of terms in the search history list            | `5`           |
+| `maxSuggestedProducts` | `Number`                                          | Maximum number of suggested products                          | `3`           |
+| `maxSuggestedTerms`    | `Number`                                          | Maximum number of suggested terms                             | `3`           |
+| `autocompleteWidth`    | `Number`                                          | Autocomplete width. Number between `0` and `100`              | -             |
+| `productLayout`        | [`ProductLayoutEnum`](#productlayoutenum)         | Defines the product layout in the suggested products list     | -             |
+| `hideTitles`           | `Boolean`                                         | If true, all the titles will be hidden                        | `false`       |
+| `historyFirst`         | `Boolean`                                         | If true, the history list will be prioritized                 | `false`       |
+| `customBreakpoints`    | [`CustomBreakpointsProp`](#custombreakpointsprop) | Defines a maximum number of suggested products by breakpoints | -             |
 
 #### ProductLayoutEnum
 
@@ -47,3 +48,18 @@ Add `autocomplete-result-list.v2` into the blocks of a `search-bar`. We also rec
 | ------------ | ------------ |
 | `Horizontal` | `HORIZONTAL` |
 | `Vertical`   | `VERTICAL`   |
+
+#### CustomBreakpointsProp
+
+| Prop name       | Type                                | Description                                  | Default value |
+| --------------- | ----------------------------------- | -------------------------------------------- | ------------- |
+| `md`            | [`BreakpointProp`](#breakpointprop) | Defines the options for the `md` breakpoint  | -             |
+| `lg`            | [`BreakpointProp`](#breakpointprop) | Defines the options for the `lg` breakpoint  | -             |
+| `xlg`           | [`BreakpointProp`](#breakpointprop) | Defines the options for the `xlg` breakpoint | -             |
+
+#### BreakpointProps
+
+| Prop name              | Type                                | Description                                             | Default value |
+| ---------------------- | ----------------------------------- | ------------------------------------                    | ------------- |
+| `width`                | `Number`                            | Minimum width for the breakpoint                        | -             |
+| `maxSuggestedProducts` | `Number`                            | Maximum number of suggested products for the breakpoint | -             |

--- a/docs/Autocomplete.md
+++ b/docs/Autocomplete.md
@@ -57,7 +57,7 @@ Add `autocomplete-result-list.v2` into the blocks of a `search-bar`. We also rec
 | `lg`            | [`BreakpointProp`](#breakpointprop) | Defines the options for the `lg` breakpoint  | -             |
 | `xlg`           | [`BreakpointProp`](#breakpointprop) | Defines the options for the `xlg` breakpoint | -             |
 
-#### BreakpointProps
+#### BreakpointProp
 
 | Prop name              | Type                                | Description                                             | Default value |
 | ---------------------- | ----------------------------------- | ------------------------------------                    | ------------- |

--- a/node/package.json
+++ b/node/package.json
@@ -16,7 +16,7 @@
     "tslint": "^5.18.0",
     "tslint-config-airbnb": "^5.11.2",
     "tslint-config-prettier": "^1.18.0",
-    "typescript": "3.7.3"
+    "typescript": "3.8.3"
   },
   "scripts": {
     "lint": "tslint './**/*.ts' -e './node_modules/**/*'"

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -1582,10 +1582,10 @@ type-is@^1.6.16:
     media-typer "0.3.0"
     mime-types "~2.1.24"
 
-typescript@3.7.3:
-  version "3.7.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.3.tgz#b36840668a16458a7025b9eabfad11b66ab85c69"
-  integrity sha512-Mcr/Qk7hXqFBXMN7p7Lusj1ktCBydylfQM/FZCk5glCNQJrCUKPkMHdo9R0MTFWsC/4kPFvDS0fDPvukfCkFsw==
+typescript@3.8.3:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
+  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
 
 universalify@^0.1.0:
   version "0.1.2"

--- a/react/components/Autocomplete/index.tsx
+++ b/react/components/Autocomplete/index.tsx
@@ -442,18 +442,12 @@ class AutoComplete extends React.Component<
         !customBreakpoints.xlg
       ) {
         return maxSuggestedProducts;
-      } else if (
-        windowWidth >= customBreakpoints.md.width &&
-        windowWidth < customBreakpoints.lg.width
-      ) {
-        return customBreakpoints.md.maxSuggestedProducts;
-      } else if (
-        windowWidth >= customBreakpoints.lg.width &&
-        windowWidth < customBreakpoints.xlg.width
-      ) {
-        return customBreakpoints.lg.maxSuggestedProducts;
       } else if (windowWidth >= customBreakpoints.xlg.width) {
         return customBreakpoints.xlg.maxSuggestedProducts;
+      } else if (windowWidth >= customBreakpoints.lg.width) {
+        return customBreakpoints.lg.maxSuggestedProducts;
+      } else if (windowWidth >= customBreakpoints.md.width) {
+        return customBreakpoints.md.maxSuggestedProducts;
       } else {
         return maxSuggestedProducts;
       }

--- a/react/components/Autocomplete/index.tsx
+++ b/react/components/Autocomplete/index.tsx
@@ -16,7 +16,7 @@ import debounce from "debounce";
 
 const MAX_TOP_SEARCHES_DEFAULT = 10;
 const MAX_SUGGESTED_TERMS_DEFAULT = 5;
-const MAX_SUGGESTED_PRODUCTS_DEFAULT = 5;
+const MAX_SUGGESTED_PRODUCTS_DEFAULT = 3;
 const MAX_HISTORY_DEFAULT = 5;
 
 export enum ProductLayout {

--- a/react/package.json
+++ b/react/package.json
@@ -22,7 +22,7 @@
     "react-apollo": "2.4.1",
     "react-dom": "^16.8.6",
     "react-intl": "^3.9.2",
-    "typescript": "3.7.3",
+    "typescript": "3.8.3",
     "unescape": "^1.0.1"
   },
   "devDependencies": {

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -3054,10 +3054,10 @@ type-fest@^0.8.1:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
 
-typescript@3.7.3:
-  version "3.7.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.3.tgz#b36840668a16458a7025b9eabfad11b66ab85c69"
-  integrity sha512-Mcr/Qk7hXqFBXMN7p7Lusj1ktCBydylfQM/FZCk5glCNQJrCUKPkMHdo9R0MTFWsC/4kPFvDS0fDPvukfCkFsw==
+typescript@3.8.3:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
+  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
 
 ua-parser-js@^0.7.18:
   version "0.7.21"


### PR DESCRIPTION
[Permite que o usuário configure o número de sugestões de produtos no autocomplete com base na largura do dispositivo.](https://biggylabs.atlassian.net/browse/BS-5126?atlOrigin=eyJpIjoiMTU3N2I5YTUyYzA1NDhiNzk2YzMyMzE2ZTYxMThhMmEiLCJwIjoiaiJ9)

Exemplo de definição nos blocks

```
"autocomplete-result-list.v2": {
    "props": {
      "customBreakpoints": {
        "md": {
          "width": 768,
          "maxSuggestedProducts": 1
        },
        "lg": {
          "width": 992,
          "maxSuggestedProducts": 2
        },
        "xlg": {
          "width": 1200,
          "maxSuggestedProducts": 3
        }
      }
    }
}
```