### PR TITLE
fix suggestionsListItem handle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- `suggestionsListItem` handle.
+
 ### Changed
 
 - Use `segmentToken` instead of `getSegment`.

--- a/docs/Suggestions.md
+++ b/docs/Suggestions.md
@@ -31,8 +31,9 @@
 
 In order to apply CSS customizations in this and other blocks, follow the instructions given in the recipe on [Using CSS Handles for store customization](https://vtex.io/docs/recipes/style/using-css-handles-for-store-customization).
 
-| CSS Handles        |
-| ------------------ |
-| `suggestionsList` |
-| `suggestionsListPrefix`   |
-| `suggestionsListLink` |
+| CSS Handles             |
+| ----------------------- |
+| `suggestionsList`       |
+| `suggestionsListPrefix` |
+| `suggestionsListLink`   |
+| `suggestionsListItem`   |

--- a/react/components/Suggestions/styles.css
+++ b/react/components/Suggestions/styles.css
@@ -8,3 +8,5 @@
 .suggestionsListPrefix {}
 
 .suggestionListWrapper {}
+
+.suggestionsListItem {}


### PR DESCRIPTION
The `suggestionListItem` was missing in the `styles.css`

We should use the `useCssHandles` from now and then, btw.