### PR TITLE
Change autocomplete overflow css property from scroll to auto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Change `autocomplete` overflow css property from `scroll` to `auto`
+
 ## [1.0.6] - 2020-05-05
 
 ### Changed

--- a/react/components/Autocomplete/styles.css
+++ b/react/components/Autocomplete/styles.css
@@ -8,10 +8,9 @@
     padding 0.6s ease-out;
   padding: 20px 0 10px 0;
   max-height: 630px;
-  webkit-box-shadow: 0 5px 7px rgba(0, 0, 0, 0.2);
   box-shadow: 0 5px 7px rgba(0, 0, 0, 0.2);
   background: #fff;
-  overflow: scroll;
+  overflow: auto;
   display: flex;
 }
 


### PR DESCRIPTION
The `autocomplete` had the bars always in windows and Linux


https://thalyta--storecomponents.myvtex.com/

Before
![image](https://user-images.githubusercontent.com/8517023/81726606-07633400-945e-11ea-8c66-025b264e3fd5.png)

After
![image](https://user-images.githubusercontent.com/8517023/81726630-10ec9c00-945e-11ea-8fed-5e768106f0e4.png)
