### PR TITLE
Update history with new searches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,26 +7,33 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- History that was not being updated.
+
 ## [1.0.15] - 2020-06-03
 
 ### Changed
+
 - Remove cacheId
 
 ## [1.0.14] - 2020-06-02
 
 ### Fixed
+
 - Remove hardcoded value in messages.
 
 ## [1.0.13] - 2020-06-02
 
 ### Changed
+
 - Replace `See more` to `See all`.
 
 ## [1.0.12] - 2020-05-26
 
 ## [1.0.11] - 2020-05-20
 
-### Fixed 
+### Fixed
 
 - Update the app documentation (README.md file)
 
@@ -39,6 +46,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [1.0.9] - 2020-05-19
 
 ### Fixed
+
 - Use `Link` instead of `a`in the "See more" button.
 
 ## [1.0.8] - 2020-05-14

--- a/react/components/Autocomplete/index.tsx
+++ b/react/components/Autocomplete/index.tsx
@@ -136,8 +136,17 @@ class AutoComplete extends React.Component<
     );
   }
 
+  addTermToHistory() {
+    const path = window.location.href.split("_q=");
+    if (path[1] && path[1].split("&")) {
+      const term = path[1].split("&")[0];
+      this.client.prependSearchHistory(decodeURI(term));
+    }
+  }
+
   componentDidUpdate(prevProps: AutoCompleteProps) {
     if (this.shouldUpdate(prevProps)) {
+      this.addTermToHistory();
       this.fitAutocompleteInWindow();
 
       const { inputValue } = this.props;

--- a/react/components/Autocomplete/index.tsx
+++ b/react/components/Autocomplete/index.tsx
@@ -138,7 +138,7 @@ class AutoComplete extends React.Component<
 
   addTermToHistory() {
     const path = window.location.href.split("_q=");
-    if (path[1] && path[1].split("&")) {
+    if (path[1]) {
       const term = path[1].split("&")[0];
       this.client.prependSearchHistory(decodeURI(term));
     }


### PR DESCRIPTION
When doing new searches on search 1.x, the history is not being updated.

[workspace](https://thalyta--storecomponents.myvtex.com)