### PR TITLE
remove cacheId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Removed
+- `cacheId` from `compatibilityLayer`.
+
 ## [1.0.9] - 2020-05-19
 
 ### Fixed

--- a/node/commons/compatibility-layer.ts
+++ b/node/commons/compatibility-layer.ts
@@ -22,7 +22,6 @@ export const convertBiggyProduct = (
 
   return {
     categories,
-    cacheId: product.link,
     productId: product.product || product.id,
     productName: product.name,
     productReference: product.reference || product.product || product.id,


### PR DESCRIPTION
When we set the cacheId in a ProductSummary, for example, the cached product is replaced by the product from the Biggy APi. It is causing problems in PDP because our product doesn't have all the info needed.
Since these products are coming from our API, we are not taking any advantage from this field, that's why I'm removing it!

[workspace](https://hiago--eriksbikeshop.myvtex.com/)