### PR TITLE
remove stock filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Remove stock filter from `convertBiggyProduct`.
+
 ## [1.0.17] - 2020-06-05
 
 ### Added

--- a/node/commons/compatibility-layer.ts
+++ b/node/commons/compatibility-layer.ts
@@ -17,7 +17,6 @@ export const convertBiggyProduct = (
     : [];
 
   const skus: any[] = propOr([], "skus", product)
-    .filter((sku: any) => propOr(product.stock, "stock", sku) > 0)
     .map(convertSKU(product, indexingType, tradePolicy));
 
   return {


### PR DESCRIPTION
This change was made in `search-resolver`, but it was not repeated here.

Don't worry, the node builder will be removed soon 😉 

[Workspace](https://search--txboot.myvtex.com/)