### PR TITLE
Fix/taxpercentage in autocomplete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Fixed
-- `taxPercentage`int autocomplete price.
+- `taxPercentage` in autocomplete price.
 
 ## [1.1.0] - 2020-06-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- `taxPercentage`int autocomplete price.
+
 ## [1.1.0] - 2020-06-17
 
 ### Changed

--- a/graphql/types/Product.graphql
+++ b/graphql/types/Product.graphql
@@ -236,6 +236,7 @@ type Offer {
   ): [Installment]
   Price: Float
   ListPrice: Float
+  taxPercentage: Float
   PriceWithoutDiscount: Float
   RewardValue: Float
   PriceValidUntil: String

--- a/manifest.json
+++ b/manifest.json
@@ -34,7 +34,8 @@
     "vtex.search-resolver": "1.x",
     "vtex.device-detector": "0.x",
     "vtex.search-page-context": "0.x",
-    "vtex.css-handles": "0.x"
+    "vtex.css-handles": "0.x",
+    "vtex.product-price": "1.x"
   },
   "policies": [
     {

--- a/node/clients/search-resolver.ts
+++ b/node/clients/search-resolver.ts
@@ -107,6 +107,7 @@ const PRODUCTS_BY_ID_QUERY = `
             }
             Price
             ListPrice
+            taxPercentage
             PriceWithoutDiscount
             RewardValue
             PriceValidUntil

--- a/node/commons/models/VtexSeller.ts
+++ b/node/commons/models/VtexSeller.ts
@@ -14,6 +14,7 @@ interface CommertialOffer {
   Price: number;
   ListPrice: number;
   PriceWithoutDiscount: number;
+  taxPercentage: number;
 }
 
 class VtexSeller {
@@ -46,6 +47,7 @@ class VtexSeller {
       Price: price,
       ListPrice: oldPrice,
       PriceWithoutDiscount: price,
+      taxPercentage: 0,
     };
   }
 }

--- a/react/components/Autocomplete/components/CustomListItem/CustomListItem.tsx
+++ b/react/components/Autocomplete/components/CustomListItem/CustomListItem.tsx
@@ -2,7 +2,8 @@ import * as React from "react";
 import { path } from "ramda";
 import { Link } from "vtex.render-runtime";
 import styles from "./styles.css";
-import ProductPrice from "vtex.store-components/ProductPrice";
+import { SellingPrice } from "vtex.product-price";
+import { ProductContextProvider } from "vtex.product-context";
 
 interface CustomListItemProps {
   product: any;
@@ -12,7 +13,6 @@ export class CustomListItem extends React.Component<CustomListItemProps> {
   render() {
     const product = this.props.product;
     const sku = path<any>(["sku"], product);
-    const commertialOffer = path<any>(["seller", "commertialOffer"], sku);
 
     return (
       <div>
@@ -42,16 +42,14 @@ export class CustomListItem extends React.Component<CustomListItemProps> {
                 </span>
               </div>
               <div className={styles.priceContainer}>
-                <ProductPrice
-                  sellingPrice={commertialOffer.Price}
-                  listPrice={commertialOffer.ListPrice}
-                  sellingPriceContainerClass="c-on-base"
-                  sellingPriceLabelClass="dib"
-                  sellingPriceClass="dib t-small c-muted-2"
-                  showListPrice={true}
-                  showLabels={false}
-                  showInstallments={false}
-                />
+                <ProductContextProvider
+                  product={product}
+                  query={{
+                    skuId: sku && sku.itemId,
+                  }}
+                >
+                  <SellingPrice message="{sellingPriceWithTax}" />
+                </ProductContextProvider>
               </div>
             </div>
           </article>

--- a/react/components/Autocomplete/components/CustomListItem/CustomListItem.tsx
+++ b/react/components/Autocomplete/components/CustomListItem/CustomListItem.tsx
@@ -48,7 +48,9 @@ export class CustomListItem extends React.Component<CustomListItemProps> {
                     skuId: sku && sku.itemId,
                   }}
                 >
-                  <SellingPrice message="{sellingPriceWithTax}" />
+                  <span className="dib t-small c-muted-2">
+                    <SellingPrice message="{sellingPriceWithTax}" />
+                  </span>
                 </ProductContextProvider>
               </div>
             </div>

--- a/react/graphql/suggestionProducts.gql
+++ b/react/graphql/suggestionProducts.gql
@@ -82,6 +82,7 @@ fragment Product on Product @context(provider: "vtex.search") {
         }
         Price
         ListPrice
+        taxPercentage
         PriceWithoutDiscount
         RewardValue
         PriceValidUntil


### PR DESCRIPTION
The "custom product-summary" in autocomplete is not considering the `taxPercentage` in price. This PR fixes this problem

[workspace](https://hiago--cbcecub2c.myvtex.com/142?map=productClusterIds)

Search for `gatorade`. The first product has a price of $0.89, but with tax, it is $1.00.

![image](https://user-images.githubusercontent.com/40380674/86039652-1c4d5400-ba19-11ea-9602-87538ce97ff0.png)
