### PR TITLE
Suggestion custom page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- New `customPage` prop on `Suggestion`
+
 ## [1.3.1] - 2020-07-22
 
 ### Fixed

--- a/docs/Suggestions.md
+++ b/docs/Suggestions.md
@@ -17,6 +17,12 @@ Add the `search-suggestions` block to the `search-result-layout.desktop` or `sea
 }
 ```
 
+### Props
+
+| Prop name    | Type     | Description                                                                           | Default value |
+| ------------ | -------- | ------------------------------------------------------------------------------------- | ------------- |
+| `customPage` | `string` | Defines the destiny page of the Link. If not, the page will be send to `store.search` | -             |
+
 ## Customization
 
 In order to apply CSS customizations in this and other blocks, follow the instructions given in the recipe on [Using CSS Handles for store customization](https://vtex.io/docs/recipes/style/using-css-handles-for-store-customization).

--- a/docs/Suggestions.md
+++ b/docs/Suggestions.md
@@ -19,9 +19,9 @@ Add the `search-suggestions` block to the `search-result-layout.desktop` or `sea
 
 ### Props
 
-| Prop name    | Type     | Description                                                                           | Default value |
-| ------------ | -------- | ------------------------------------------------------------------------------------- | ------------- |
-| `customPage` | `string` | Defines the destiny page of the Link. If not, the page will be send to `store.search` | -             |
+| Prop name    | Type     | Description                                                                                                    | Default value |
+| ------------ | -------- | -------------------------------------------------------------------------------------------------------------- | ------------- |
+| `customPage` | `string` | Defines a custom page to the link of a suggestion. Example: `store.search.custom`. Defaults to `store.search`. |               |
 
 ## Customization
 

--- a/react/components/Suggestions/index.tsx
+++ b/react/components/Suggestions/index.tsx
@@ -1,10 +1,14 @@
-import React from "react";
+import React, { FC } from "react";
 import { Link } from "vtex.render-runtime";
 import styles from "./styles.css";
 import { FormattedMessage } from "react-intl";
 import searchSuggestionsQuery from "vtex.store-resources/QuerySearchSuggestions";
 import { useSearchPage } from "vtex.search-page-context/SearchPageContext";
 import { useQuery } from "react-apollo";
+
+interface SuggestionsProps {
+  customPage: string;
+}
 
 interface Suggestion {
   searches: {
@@ -13,7 +17,7 @@ interface Suggestion {
   }[];
 }
 
-const Suggestions = () => {
+const Suggestions: FC<SuggestionsProps> = ({ customPage }) => {
   const {
     searchQuery: {
       variables: { fullText },
@@ -49,7 +53,11 @@ const Suggestions = () => {
           <li className={styles.suggestionsListItem} key={search.term}>
             <Link
               className={`${styles.suggestionsListLink} link f7`}
-              to={`/${search.term}?map=ft`}
+              page={customPage || "store.search"}
+              query="map=ft"
+              params={{
+                term: search.term,
+              }}
             >
               {search.term}
             </Link>


### PR DESCRIPTION
We have a custom Search Page on URL `/busca/{term}` and to make the component works with our page new need this prop to change the page correctly.

https://searchpage--carrefourbr.myvtex.com/

To you guys do not find problems, add a cookie `hybridSearch=true` on your browsers please. 

To configure:
![image](https://user-images.githubusercontent.com/49173685/88683483-3cc90680-d0ca-11ea-9276-8b73384081f4.png)

![image](https://user-images.githubusercontent.com/49173685/88683542-4e121300-d0ca-11ea-8896-ab07c4f1792b.png)
