### PR TITLE
Fix price on the mobile autocomplete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Price on the mobile Autocomplete that displayed `NaN` when there is no `taxPercentage`.
+
 ## [2.0.1] - 2020-09-08
 
 ### Fixed

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -1529,7 +1529,7 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
-"stats-lite@github:vtex/node-stats-lite#dist":
+stats-lite@vtex/node-stats-lite#dist:
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:

--- a/react/components/Autocomplete/components/CustomListItem/CustomListItem.tsx
+++ b/react/components/Autocomplete/components/CustomListItem/CustomListItem.tsx
@@ -13,6 +13,7 @@ export class CustomListItem extends React.Component<CustomListItemProps> {
   render() {
     const product = this.props.product;
     const sku = path<any>(["sku"], product);
+    const taxPercentage = sku?.sellers?.[0]?.commertialOffer?.taxPercentage;
 
     return (
       <div>
@@ -49,10 +50,22 @@ export class CustomListItem extends React.Component<CustomListItemProps> {
                   }}
                 >
                   <span className="db f7 c-muted-2">
-                    <ListPrice message="{listPriceWithTax}" />
+                    <ListPrice
+                      message={
+                        taxPercentage
+                          ? "{listPriceWithTax}"
+                          : "{listPriceValue}"
+                      }
+                    />
                   </span>
                   <span className="dib t-small c-muted-2">
-                    <SellingPrice message="{sellingPriceWithTax}" />
+                    <SellingPrice
+                      message={
+                        taxPercentage
+                          ? "{sellingPriceWithTax}"
+                          : "{sellingPriceValue}"
+                      }
+                    />
                   </span>
                 </ProductContextProvider>
               </div>


### PR DESCRIPTION

Before:

![Screen Shot 2020-09-16 at 10 45 20 AM](https://user-images.githubusercontent.com/20840671/93348976-4a1e8980-f80d-11ea-94ed-5eedfb35c5cc.png)


[Workspace](https://search--ihhcomprei.myvtex.com/)
- in the mobile version, search for something (eg: `pantufas`) and wait for the autocomplete to appear
- check if the correct price is displayed