### PR TITLE
Increase maxReplicas to 80

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Increase maxReplicas to 80.
 
 ## [0.13.0] - 2020-09-25
 

--- a/node/service.json
+++ b/node/service.json
@@ -3,5 +3,5 @@
   "ttl": 10,
   "timeout": 20,
   "minReplicas": 8,
-  "maxReplicas": 20
+  "maxReplicas": 80
 }


### PR DESCRIPTION
As per the BF Investigation of Scalings, I found out that a safer maxReplicas for this app would be 80.

Here's the full list:
https://github.com/vtex/io-infra-tools/blob/master/bf-2020/critical-apps/scalings.txt#L25