### PR TITLE
Fix/sanitize label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-### Fixex
+### Fixed
 - Added sanitize function in `string-utils` and using in `history` label in `Autocomplete`
 
 ## [2.2.0] - 2020-12-02

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixex
+- Added sanitize function in `string-utils` and using in `history` label in `Autocomplete`
+
 ## [2.2.0] - 2020-12-02
 
 ### Added

--- a/react/components/Autocomplete/index.tsx
+++ b/react/components/Autocomplete/index.tsx
@@ -16,6 +16,7 @@ import { withDevice } from "vtex.device-detector";
 import debounce from "debounce";
 import { withPixel } from "vtex.pixel-manager/PixelContext";
 import { withRuntime } from "../../utils/withRuntime";
+import { sanitizeString } from "../../utils/string-utils"
 import {
   EventType,
   handleAutocompleteSearch,
@@ -334,7 +335,7 @@ class AutoComplete extends React.Component<
       .slice(0, this.props.maxHistory || MAX_HISTORY_DEFAULT)
       .map((item: string) => {
         return {
-          label: item,
+          label: sanitizeString(item),
           value: item,
           link: `/${item}?map=ft`,
           icon: <IconClock />,

--- a/react/utils/string-utils.ts
+++ b/react/utils/string-utils.ts
@@ -9,3 +9,7 @@ export function removeBaseUrl(url: string) {
 
   return url;
 }
+
+export function sanitizeString(str: string) {
+  return str.replace(/\$2F/gi, '/')
+}


### PR DESCRIPTION
#### What problem is this solving?

Fixing text inside history, because history gets the encoded string that we pass when we search and encode it to backend. So, i'm treating the response from server

#### How to test it?

Go to searchbar and type something with " / ", in history you will see that

Before fix
![image](https://user-images.githubusercontent.com/13649073/102229529-ab1c3300-3eca-11eb-9643-1b5b98d417d7.png)

After fix
![image](https://user-images.githubusercontent.com/13649073/102229337-6ee8d280-3eca-11eb-86d5-78e788601a23.png)

You can test the fix in this workspace: 
https://iespinoza--dunloppneus.myvtex.com/111$2f222?_q=111$2F222&map=ft

#### Describe alternatives you've considered, if any.

I've created with the name "sanitize text" because maybe we could have another fix in string to made in encode

#### How does this PR make you feel? [:link:](http://giphy.com/)

![](https://media.giphy.com/media/H6c7BuWD0duRdSgbSP/giphy.gif)