### PR TITLE
Fix/forward slash encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Added encoding and decoding function in `string-utils` preventing unexpected behaviors in url
 
 ## [2.3.0] - 2021-01-12
 

--- a/react/components/Autocomplete/index.tsx
+++ b/react/components/Autocomplete/index.tsx
@@ -20,7 +20,8 @@ import {
 } from './components/ItemList/types'
 import { ItemList } from './components/ItemList/ItemList'
 import { withRuntime } from '../../utils/withRuntime'
-import { sanitizeString } from '../../utils/string-utils'
+import { decodeUrlString, encodeUrlString } from '../../utils/string-utils'
+
 import {
   EventType,
   handleAutocompleteSearch,
@@ -350,7 +351,7 @@ class AutoComplete extends React.Component<
       .slice(0, this.props.maxHistory || MAX_HISTORY_DEFAULT)
       .map((item: string) => {
         return {
-          label: sanitizeString(item),
+          label: decodeUrlString(item),
           value: item,
           link: `/${item}?map=ft`,
           icon: <IconClock />,
@@ -454,30 +455,34 @@ class AutoComplete extends React.Component<
   }
 
   contentWhenQueryIsNotEmpty() {
+    const {products, totalProducts, isProductsLoading} = this.state
+    const {hideTitles, push, runtime, inputValue} = this.props
+    const inputValueEncoded = encodeUrlString(inputValue)
+
     return (
       <>
         {this.renderSuggestions()}
         <TileList
-          term={this.props.inputValue || ''}
+          term={inputValueEncoded || ""}
           shelfProductCount={this.getProductCount()}
           title={
             <FormattedMessage
-              id="store/suggestedProducts"
-              values={{ term: this.props.inputValue }}
+              id={"store/suggestedProducts"}
+              values={{term: inputValue}}
             />
           }
-          products={this.state.products || []}
-          showTitle={!this.props.hideTitles}
-          totalProducts={this.state.totalProducts || 0}
+          products={products || []}
+          showTitle={!hideTitles}
+          totalProducts={totalProducts || 0}
           layout={this.getProductLayout()}
-          isLoading={this.state.isProductsLoading}
+          isLoading={isProductsLoading}
           onProductClick={handleProductClick(
-            this.props.push,
-            this.props.runtime.page
+            push,
+            runtime.page,
           )}
           onSeeAllClick={handleSeeAllClick(
-            this.props.push,
-            this.props.runtime.page
+            push,
+            runtime.page,
           )}
         />
       </>

--- a/react/utils/string-utils.ts
+++ b/react/utils/string-utils.ts
@@ -10,6 +10,10 @@ export function removeBaseUrl(url: string) {
   return url
 }
 
-export function sanitizeString(str: string) {
+export function decodeUrlString(str: string) {
   return str.replace(/\$2F/gi, '/')
+}
+
+export function encodeUrlString(str: string) {
+  return str.replace(/\//gi, '$2F')
 }


### PR DESCRIPTION
Encoding and decoding forward slash in URL in Autocomplete component when needed duo to problems with special characters

![image](https://user-images.githubusercontent.com/13649073/104963617-afe87100-59b9-11eb-9376-e3cd5c17190b.png)

You can test it in: https://iespinoza2--dunloppneus.myvtex.com, typing something like "245/70" in searchbar and clicking in "veja todos os x produtos"
