### PR TITLE
PER-1009: Close autocomplete when clicking on an item inside it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Close autocomplete when clicking on an item inside it.
+
 ## [2.7.0] - 2021-03-18
 
 ### Added

--- a/react/components/Autocomplete/index.tsx
+++ b/react/components/Autocomplete/index.tsx
@@ -77,6 +77,7 @@ interface AutoCompleteProps {
     actionOnClick: () => void
   }>
   customPage?: string
+  closeMenu: () => void
 }
 
 interface AutoCompleteState {
@@ -171,6 +172,12 @@ class AutoComplete extends React.Component<
       const term = path[1].split('&')[0]
 
       this.client.prependSearchHistory(decodeURI(term))
+    }
+  }
+
+  closeModal() {
+    if (this.props.closeMenu) {
+      this.props.closeMenu()
     }
   }
 
@@ -410,11 +417,14 @@ class AutoComplete extends React.Component<
         showTitle={!hasSuggestion || !this.props.hideTitles}
         onItemHover={this.handleItemHover}
         showTitleOnEmpty={this.props.maxSuggestedTerms !== 0}
-        onItemClick={handleItemClick(
-          this.props.push,
-          this.props.runtime.page,
-          EventType.SearchSuggestionClick
-        )}
+        onItemClick={(value, position) => {
+          handleItemClick(
+            this.props.push,
+            this.props.runtime.page,
+            EventType.SearchSuggestionClick
+          )(value, position)
+          this.closeModal()
+        }}
         customPage={this.props.customPage}
       />
     )
@@ -436,11 +446,14 @@ class AutoComplete extends React.Component<
             title={<FormattedMessage id="store/topSearches" />}
             items={this.state.topSearchedItems || []}
             showTitle={!this.props.hideTitles}
-            onItemClick={handleItemClick(
-              this.props.push,
-              this.props.runtime.page,
-              EventType.TopSearchClick
-            )}
+            onItemClick={(value, position) => {
+              handleItemClick(
+                this.props.push,
+                this.props.runtime.page,
+                EventType.TopSearchClick
+              )(value, position)
+              this.closeModal()
+            }}
             customPage={this.props.customPage}
           />
         ) : null}
@@ -452,11 +465,14 @@ class AutoComplete extends React.Component<
             title={<FormattedMessage id="store/history" />}
             items={this.state.history || []}
             showTitle={!this.props.hideTitles}
-            onItemClick={handleItemClick(
-              this.props.push,
-              this.props.runtime.page,
-              EventType.HistoryClick
-            )}
+            onItemClick={(value, position) => {
+              handleItemClick(
+                this.props.push,
+                this.props.runtime.page,
+                EventType.HistoryClick
+              )(value, position)
+              this.closeModal()
+            }}
             customPage={this.props.customPage}
           />
         ) : null}
@@ -486,8 +502,14 @@ class AutoComplete extends React.Component<
           totalProducts={totalProducts || 0}
           layout={this.getProductLayout()}
           isLoading={isProductsLoading}
-          onProductClick={handleProductClick(push, runtime.page)}
-          onSeeAllClick={handleSeeAllClick(push, runtime.page)}
+          onProductClick={(id, position) => {
+            handleProductClick(push, runtime.page)(id, position)
+            this.closeModal()
+          }}
+          onSeeAllClick={term => {
+            handleSeeAllClick(push, runtime.page)(term)
+            this.closeModal()
+          }}
           HorizontalProductSummary={this.props.HorizontalProductSummary}
         />
       </>


### PR DESCRIPTION
Fixes https://github.com/vtex-apps/store-discussion/issues/412

There are some scenarios where the autocomplete is not closing after clicking on an item inside it:
- On a search page, open the autocomplete and click on a top search or a search history item
- On a search page, type something and click on the "see more" button or on a search suggestions item
- On a product page, type something and click on a product from the suggestions

To fix it, we need after each click to call the `closeMenu` function that we receive from the Downshift lib.

Note that this doesn't affect the behavior of clicking on the `AddToCart` or `AddToCartQuantityStepper` components inside the autocomplete (in this case, we don't want the autocomplete to close)

[Workspace](https://autocomplete--stcroix.myvtex.com/accessories)

Before:

https://user-images.githubusercontent.com/20840671/111635671-817aec80-87d6-11eb-85cf-d8aab7ceb30f.mp4

https://user-images.githubusercontent.com/20840671/111635683-8475dd00-87d6-11eb-9cd6-de4cff582968.mp4

After:

https://user-images.githubusercontent.com/20840671/111635767-9c4d6100-87d6-11eb-94c6-44160354855e.mp4

https://user-images.githubusercontent.com/20840671/111635778-9f485180-87d6-11eb-88a8-46a9b15fd16e.mp4


AddToCart:

https://user-images.githubusercontent.com/20840671/111635808-a707f600-87d6-11eb-9050-4ad5a619558f.mp4

