### PR TITLE
add x-vtex-provider-header-and-update-dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Add missing `x-vtex-provider` to the `search-resolver` call.
+
 ## [1.4.3] - 2020-09-16
 
 ### Fixed

--- a/node/clients/search-resolver.ts
+++ b/node/clients/search-resolver.ts
@@ -3,7 +3,13 @@ import { pathOr } from "ramda";
 
 export class SearchResolver extends AppGraphQLClient {
   constructor(context: IOContext, options?: InstanceOptions) {
-    super("vtex.search-resolver", context, options);
+    super("vtex.search-resolver", context, {
+      ...options,
+      headers: {
+        ...(options?.headers ?? {}),
+        'x-vtex-provider': 'vtex.search-graphql'
+      },
+    });
   }
 
   public productsById = async (ids: string[]) => {

--- a/node/clients/search-resolver.ts
+++ b/node/clients/search-resolver.ts
@@ -7,7 +7,7 @@ export class SearchResolver extends AppGraphQLClient {
       ...options,
       headers: {
         ...(options?.headers ?? {}),
-        'x-vtex-provider': 'vtex.search-graphql'
+        'x-vtex-provider': 'vtex.search-graphql@0.43.0'
       },
     });
   }

--- a/node/package.json
+++ b/node/package.json
@@ -18,7 +18,7 @@
     "tslint": "^5.18.0",
     "tslint-config-airbnb": "^5.11.2",
     "tslint-config-prettier": "^1.18.0",
-    "typescript": "3.8.3"
+    "typescript": "3.9.7"
   },
   "scripts": {
     "lint": "tslint './**/*.ts' -e './node_modules/**/*'"

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -1592,10 +1592,10 @@ type-is@^1.6.16:
     media-typer "0.3.0"
     mime-types "~2.1.24"
 
-typescript@3.8.3:
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
-  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
+typescript@3.9.7:
+  version "3.9.7"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
+  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
 
 universalify@^0.1.0:
   version "0.1.2"

--- a/react/package.json
+++ b/react/package.json
@@ -23,7 +23,7 @@
     "react-apollo": "2.4.1",
     "react-dom": "^16.8.6",
     "react-intl": "^3.9.2",
-    "typescript": "3.8.3",
+    "typescript": "3.9.7",
     "unescape": "^1.0.1",
     "vtex": "^2.77.11"
   },

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -6160,10 +6160,10 @@ type-is@^1.6.16:
     media-typer "0.3.0"
     mime-types "~2.1.24"
 
-typescript@3.8.3:
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
-  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
+typescript@3.9.7:
+  version "3.9.7"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
+  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
 
 ua-parser-js@^0.7.18:
   version "0.7.21"


### PR DESCRIPTION
#### What problem is this solving?

https://github.com/vtex/graphql-server/pull/251 adds the `x-vtex-provider` header to the search-graphql calls. But, the `search-resolver` client in this project doesn't have this header.

This missing header was causing problems when the https://github.com/vtex/node-vtex-api/pull/420 was deployed. The `suggestionProducts` query was returning an error.

#### How should this be manually tested?

[Broken WS](https://hiago2--dzarm.myvtex.com/)
[Fixed WS](https://hiago--dzarm.myvtex.com/)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️| Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

