### PR TITLE
Fix link to see more products

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Link to see more products.
+
 ## [2.8.2] - 2021-07-05
 
 ### Fixed

--- a/docs/Autocomplete.md
+++ b/docs/Autocomplete.md
@@ -44,7 +44,7 @@ Add `autocomplete-result-list.v2` into the blocks of a `search-bar`. We also rec
 | `customBreakpoints`           | [`CustomBreakpointsProp`](#custombreakpointsprop) | Defines a maximum number of suggested products by breakpoints                                                                                                                       | -             |
 | `__unstableProductOriginVtex` | `Boolean`                                         | You can use this property as `true` if any of your product-summary props come with a `null` value. This is because some product information does not come by default in the Search. | `false`       |
 | `simulationBehavior`          | `"skip"` or `"default"`                           | If you want faster searches and do not care about most up to date prices and promotions, use `"skip"` value.                                                                        | `default`     |
-| `customPage` | `string` | Defines a custom page to the link of a suggestion. Example: `store.search.custom` |  `store.search`
+| `customPage` | `string` | Defines a custom page to the autocomplete links. Example: `store.search.custom` |  `store.search`
 
 #### ProductLayoutEnum
 

--- a/messages/context.json
+++ b/messages/context.json
@@ -1,11 +1,11 @@
 {
-    "store/topSearches": "topSearches",
-    "store/history": "history",
-    "store/suggestions" : "suggestions",
-    "store/emptySuggestion": "emptySuggestion",
-    "store/seeMore": "seeMore",
-    "store/suggestedProducts": "suggestedProducts",
-    "store/ordinalNumber": "ordinalNumber",
-    "store/didYouMean": "didYouMean",
-    "store/searchSuggestions": "searchSuggestions"
+  "store/topSearches": "topSearches",
+  "store/history": "history",
+  "store/suggestions": "suggestions",
+  "store/emptySuggestion": "emptySuggestion",
+  "store/seeMore": "seeMore",
+  "store/suggestedProducts": "suggestedProducts",
+  "store/ordinalNumber": "ordinalNumber",
+  "store/didYouMean": "didYouMean",
+  "store/searchSuggestions": "searchSuggestions"
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -1,11 +1,11 @@
 {
-    "store/topSearches": "Top Searches",
-    "store/history": "Search History",
-    "store/suggestions" : "Suggestions",
-    "store/emptySuggestion": "No Suggestions",
-    "store/seeMore": "See all {count} products",
-    "store/suggestedProducts": "Products for {term}",
-    "store/ordinalNumber": ".",
-    "store/didYouMean": "Did you mean",
-    "store/searchSuggestions": "Suggestions"
+  "store/topSearches": "Top Searches",
+  "store/history": "Search History",
+  "store/suggestions": "Suggestions",
+  "store/emptySuggestion": "No Suggestions",
+  "store/seeMore": "See all {count} products",
+  "store/suggestedProducts": "Products for {term}",
+  "store/ordinalNumber": ".",
+  "store/didYouMean": "Did you mean",
+  "store/searchSuggestions": "Suggestions"
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -1,11 +1,11 @@
 {
-    "store/topSearches": "Términos más buscados",
-    "store/history": "Últimas búsquedas",
-    "store/suggestions" : "Sugerencias",
-    "store/emptySuggestion": "Sin Sugerencias",
-    "store/seeMore": "Ver todos los {count} productos",
-    "store/suggestedProducts": "Productos para {term}",
-    "store/ordinalNumber": ".",
-    "store/didYouMean": "Querías decir",
-    "store/searchSuggestions": "Sugerencias"
+  "store/topSearches": "Términos más buscados",
+  "store/history": "Últimas búsquedas",
+  "store/suggestions": "Sugerencias",
+  "store/emptySuggestion": "Sin Sugerencias",
+  "store/seeMore": "Ver todos los {count} productos",
+  "store/suggestedProducts": "Productos para {term}",
+  "store/ordinalNumber": ".",
+  "store/didYouMean": "Querías decir",
+  "store/searchSuggestions": "Sugerencias"
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -1,11 +1,11 @@
 {
-    "store/topSearches": "Termos mais buscados",
-    "store/history": "Histórico de buscas",
-    "store/suggestions" : "Sugestões",
-    "store/emptySuggestion": "Sem Sugestões",
-    "store/seeMore": "Veja todos os {count} produtos",
-    "store/suggestedProducts": "Produtos para {term}",
-    "store/ordinalNumber": "º",
-    "store/didYouMean": "Você quis dizer",
-    "store/searchSuggestions": "Sugestões"
+  "store/topSearches": "Termos mais buscados",
+  "store/history": "Histórico de buscas",
+  "store/suggestions": "Sugestões",
+  "store/emptySuggestion": "Sem Sugestões",
+  "store/seeMore": "Veja todos os {count} produtos",
+  "store/suggestedProducts": "Produtos para {term}",
+  "store/ordinalNumber": "º",
+  "store/didYouMean": "Você quis dizer",
+  "store/searchSuggestions": "Sugestões"
 }

--- a/react/components/Autocomplete/components/TileList/TileList.tsx
+++ b/react/components/Autocomplete/components/TileList/TileList.tsx
@@ -11,6 +11,7 @@ import { ProductLayout } from '../..'
 interface TileListProps {
   term: string
   title: string | JSX.Element
+  customPage?: string
   products: any[]
   showTitle: boolean
   shelfProductCount: number
@@ -36,6 +37,7 @@ const TileList: FC<TileListProps> = ({
   onProductClick,
   onSeeAllClick,
   HorizontalProductSummary,
+  customPage,
 }) => {
   if (products.length === 0 && !isLoading) {
     return null
@@ -99,8 +101,11 @@ const TileList: FC<TileListProps> = ({
           <footer className={styles.tileListFooter}>
             {totalProducts > 0 ? (
               <Link
-                to={`/${term}`}
                 query="map=ft"
+                params={{
+                  term,
+                }}
+                page={customPage || 'store.search'}
                 className={styles.tileListSeeMore}
                 onClick={() => onSeeAllClick(term)}
               >

--- a/react/components/Autocomplete/index.tsx
+++ b/react/components/Autocomplete/index.tsx
@@ -493,6 +493,7 @@ class AutoComplete extends React.Component<
         {this.renderSuggestions()}
         <TileList
           term={inputValueEncoded || ''}
+          customPage={this.props.customPage}
           shelfProductCount={this.getProductCount()}
           title={
             <FormattedMessage

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -1,9 +1,7 @@
 {
   "autocomplete-result-list.v2": {
     "component": "Autocomplete",
-    "required": [
-      "product-summary"
-    ]
+    "required": ["product-summary"]
   },
   "did-you-mean": {
     "component": "DidYouMean"


### PR DESCRIPTION
Use `customPage` prop to build the link to see more products

[Before](https://intelligentsearch--carrefourbr.myvtex.com)
![before](https://user-images.githubusercontent.com/20840671/123639705-d88d5600-d7f6-11eb-87f6-e3217f6f5776.gif)

[After](https://intelligentsearch1--carrefourbr.myvtex.com)
![after](https://user-images.githubusercontent.com/20840671/123639725-dc20dd00-d7f6-11eb-906a-95c38d943d53.gif)

