### PR TITLE
Fix autocomplete for search terms with percentage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Autocomplete did not display products for search terms with percentage.
+
 ## [0.13.2] - 2021-06-09
 
 ### Fixed

--- a/react/utils/pixel.ts
+++ b/react/utils/pixel.ts
@@ -64,14 +64,27 @@ export function handleAutocompleteSearch(
   count: number,
   term: string,
 ) {
-  push({
-    event: EVENT_NAME,
-    eventType: EventType.Search,
-    search: {
-      operator,
-      misspelled,
-      text: decodeURI(term),
-      match: count,
-    },
-  });
+  try {
+    push({
+      event: EVENT_NAME,
+      eventType: EventType.Search,
+      search: {
+        operator,
+        misspelled,
+        text: decodeURI(term),
+        match: count,
+      },
+    });
+  } catch (e) {
+    push({
+      event: EVENT_NAME,
+      eventType: EventType.Search,
+      search: {
+        operator,
+        misspelled,
+        text: term,
+        match: count,
+      },
+    });
+  }
 }


### PR DESCRIPTION
When searching for terms that contains a percentage (`%`), the autocomplete doesn't load the results due to a decode error and keeps displaying a loading:
![before](https://user-images.githubusercontent.com/20840671/124172065-c07c3780-da7f-11eb-96ae-357b46503597.gif)

error:
![image](https://user-images.githubusercontent.com/20840671/124172168-e1448d00-da7f-11eb-90fa-7cc97583ba9b.png)

After: [workspace](https://thalyta--natue.myvtex.com)
![after](https://user-images.githubusercontent.com/20840671/124172373-1e108400-da80-11eb-8201-2547cac86443.gif)

