### PR TITLE
Fix searches with percentage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Autocomplete did not display products for search terms with percentage.
+
 ## [2.8.1] - 2021-06-29
 
 ### Added

--- a/react/utils/pixel.ts
+++ b/react/utils/pixel.ts
@@ -59,14 +59,27 @@ export function handleAutocompleteSearch(
   count: number,
   term: string
 ) {
-  push({
-    event: EVENT_NAME,
-    eventType: EventType.Search,
-    search: {
-      operator,
-      misspelled,
-      text: decodeURI(term),
-      match: count,
-    },
-  })
+  try {
+    push({
+      event: EVENT_NAME,
+      eventType: EventType.Search,
+      search: {
+        operator,
+        misspelled,
+        text: decodeURI(term),
+        match: count,
+      },
+    })
+  } catch (e) {
+    push({
+      event: EVENT_NAME,
+      eventType: EventType.Search,
+      search: {
+        operator,
+        misspelled,
+        text: term,
+        match: count,
+      },
+    })
+  }
 }


### PR DESCRIPTION
When searching for terms that contains a percentage (%), the autocomplete doesn't load the results due to a decode error and keeps displaying a loading.

Related to https://github.com/vtex-apps/search/pull/141