### PR TITLE
Add query string _q to autocomplete links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- `_q` query string to Autocomplete links.
+
 ## [2.8.6] - 2021-12-08
 ### Fixed
 - Safely decoding URI components to prevent errors when the search query contains breaking characters such as "%"

--- a/react/components/Autocomplete/components/ItemList/ItemList.tsx
+++ b/react/components/Autocomplete/components/ItemList/ItemList.tsx
@@ -83,7 +83,7 @@ export class ItemList extends React.Component<ItemListProps> {
                   params={{
                     term: item.value,
                   }}
-                  query="map=ft"
+                  query={`map=ft&_q=${item.value}`}
                   onClick={() => this.props.onItemClick(item.value, index)}
                   className={stylesCss.itemListLink}
                 >

--- a/react/components/Autocomplete/components/TileList/TileList.tsx
+++ b/react/components/Autocomplete/components/TileList/TileList.tsx
@@ -101,7 +101,7 @@ const TileList: FC<TileListProps> = ({
           <footer className={styles.tileListFooter}>
             {totalProducts > 0 ? (
               <Link
-                query="map=ft"
+                query={`map=ft&_q=${term}`}
                 params={{
                   term,
                 }}


### PR DESCRIPTION
We need to add `_q` inside our links because it's used for GA reports.
[workspace](https://thalyta--biggy.myvtex.com/camisa?_q=camisa&map=ft)

![image](https://user-images.githubusercontent.com/20840671/144110347-89a51be1-aa6b-46ac-b859-f6501b8388d3.png)
![image](https://user-images.githubusercontent.com/20840671/144110387-de3812d1-e10b-4b48-9675-d6fc05d25d34.png)
