### PR TITLE
Fix product suggestions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Product suggestions that was not respecting the `maxSuggestedProducts` value.
+
 ## [2.13.0] - 2022-04-28
 
 ### Added

--- a/react/components/Autocomplete/index.tsx
+++ b/react/components/Autocomplete/index.tsx
@@ -311,7 +311,8 @@ class AutoComplete extends React.Component<
       __unstableProductOrigin === 'VTEX' || __unstableProductOriginVtex,
       simulationBehavior,
       hideUnavailableItems,
-      orderBy
+      orderBy,
+      this.props.maxSuggestedProducts || MAX_SUGGESTED_PRODUCTS_DEFAULT
     )
 
     if (!queryFromHover) {

--- a/react/utils/biggy-client.ts
+++ b/react/utils/biggy-client.ts
@@ -40,7 +40,8 @@ export default class BiggyClient {
     productOrigin = false,
     simulationBehavior: 'default' | 'skip' | null = 'default',
     hideUnavailableItems = false,
-    orderBy?: string
+    orderBy?: string,
+    count?: number
   ): Promise<ApolloQueryResult<{ productSuggestions: IProductsOutput }>> {
     return this.client.query({
       query: suggestionProducts,
@@ -52,6 +53,7 @@ export default class BiggyClient {
         facetKey: attributeKey,
         facetValue: attributeValue,
         productOriginVtex: productOrigin,
+        count,
       },
       fetchPolicy: 'network-only',
     })


### PR DESCRIPTION
Currently, the query always returns 5 suggested products. If the maximum is less than 5, a slice is made. 
However, if the store wants to display more than 5 suggestions, this won't work.

[workspace](https://ametllerorigen.myvtex.com)
the autocomplete should display 12 suggested products