### PR TITLE
Add `rootPath` prefix to session endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Add `rootPath` to Session API calls.
 
 ## [2.16.1] - 2023-05-17
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "search",
   "vendor": "vtex",
-  "version": "2.16.1",
+  "version": "2.16.2-beta.0",
   "title": "Search",
   "description": "Search components and functionality for VTEX IO.",
   "scripts": {

--- a/react/components/Autocomplete/index.tsx
+++ b/react/components/Autocomplete/index.tsx
@@ -306,7 +306,7 @@ class AutoComplete extends React.Component<
       isProductsLoading: true,
     })
 
-    const session = await getSession(this.props.rootPath)
+    const session = await getSession(this.props.runtime.rootPath)
     const shippingOptions =
       session?.map((item: Record<string, string>) => item.value) ?? []
 

--- a/react/components/Autocomplete/index.tsx
+++ b/react/components/Autocomplete/index.tsx
@@ -43,7 +43,7 @@ export enum ProductLayout {
 
 interface AutoCompleteProps {
   isOpen: boolean
-  runtime: { page: string }
+  runtime: { page: string; rootPath?: string }
   inputValue: string
   maxTopSearches: number
   maxSuggestedTerms: number
@@ -306,7 +306,7 @@ class AutoComplete extends React.Component<
       isProductsLoading: true,
     })
 
-    const session = await getSession()
+    const session = await getSession(this.props.rootPath)
     const shippingOptions =
       session?.map((item: Record<string, string>) => item.value) ?? []
 

--- a/react/utils/getSession.tsx
+++ b/react/utils/getSession.tsx
@@ -1,4 +1,4 @@
-const getSession = async () => {
+const getSession = async (rootPath?: string) => {
   const headers = new Headers()
 
   headers.append('Content-Type', 'application/json')
@@ -10,7 +10,7 @@ const getSession = async () => {
   }
 
   const session = await fetch(
-    `${window.location.origin}/api/sessions?items=public.shippingOption`,
+    `${rootPath || ''}/api/sessions?items=public.shippingOption`,
     requestOptions
   )
 


### PR DESCRIPTION
Analog to [this](https://github.com/vtex-apps/search-result/pull/629). Add the `rootPath` prefix to the session requests like GraphQL does.