### PR TITLE
added full URL to subItemLink

### DIFF
--- a/react/components/Autocomplete/components/ItemList/Attribute.tsx
+++ b/react/components/Autocomplete/components/ItemList/Attribute.tsx
@@ -25,8 +25,7 @@ const Attribute = (props: IAttributeProps) =>
         >
           <Link
             className={`${stylesCss.itemListSubItemLink} c-on-base`}
-            to={`/${props.item.value}/${attribute.value}`}
-            query={`map=ft,${attribute.key}`}
+            to={`/${props.item.value}/${attribute.value}?map=ft,${attribute.key}`}
             onClick={() => props.closeModal()}
           >
             {attribute.label}


### PR DESCRIPTION
When opening the subItemLink on a new page, the query parameters were not added to the URL. 

<img width="804" alt="Screenshot 2023-06-12 at 9 34 02 AM" src="https://github.com/vtex-apps/search/assets/88678995/7f2adfb2-d701-4780-863c-361bb86f5570">



I have added the parameters used in the "query" to the "to", as this parameter expects the full URL. Below is a photo of the change. It is possible to see that the URL has all the parameters needed and if the customer opens it in another page, it will load the page as expected.
![image](https://github.com/vtex-apps/search/assets/88678995/da903653-529d-4811-b1b4-c1fc91b26d08)

The following workspaces have the changes applied and can be used for validation:
https://rjant--caeexchangeqa.myvtex.com/
https://newattributelink--motorolaus.myvtex.com/

