### PR TITLE
fix: add search suggestion event to click in suggestion attribute list

### DIFF
--- a/react/components/Autocomplete/components/ItemList/Attribute.tsx
+++ b/react/components/Autocomplete/components/ItemList/Attribute.tsx
@@ -9,6 +9,7 @@ interface IAttributeProps {
   onMouseOver: (ee: React.MouseEvent | React.FocusEvent, item: Item) => void
   onMouseOut: () => void
   closeModal: () => void
+  onItemClick: (term: string, position: number) => void
 }
 
 const Attribute = (props: IAttributeProps) =>
@@ -27,7 +28,10 @@ const Attribute = (props: IAttributeProps) =>
             className={`${stylesCss.itemListSubItemLink} c-on-base`}
             to={`/${props.item.value}/${attribute.value}`}
             query={`map=ft,${attribute.key}`}
-            onClick={() => props.closeModal()}
+            onClick={() => {
+              props.closeModal()
+              props.onItemClick(attribute.label, index)
+            }}
           >
             {attribute.label}
           </Link>

--- a/react/components/Autocomplete/components/ItemList/ItemList.tsx
+++ b/react/components/Autocomplete/components/ItemList/ItemList.tsx
@@ -106,6 +106,7 @@ export class ItemList extends React.Component<ItemListProps> {
                   onMouseOver={this.handleMouseOver}
                   onMouseOut={this.handleMouseOut}
                   closeModal={this.props.closeModal}
+                  onItemClick={this.props.onItemClick}
                 />
               </li>
             )


### PR DESCRIPTION
**What problem is this solving?**
Event autocomplete with type `search_suggestion_click` not send to click in attributes in the suggestion list
This fix it to add event from click in attribute link

Screenshot with suggestions attributes
![image](https://github.com/vtex-apps/search/assets/16208496/18646fbb-a8cf-4658-9639-83dce96d731d)


**What verify changes**

With this script you can view in console the events send from autocomplete.
And check a new event when click in suggestion attribute

```js
window.addEventListener(
  "message",
  (event) => {
      
    if (!event.data.event && event.data.event !== "autocomplete") return;

    console.log(event.data)
  }
);
```