### PR TITLE
Add Hungarian translations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+
+- Hungarian translations.
+
 ## [2.16.10] - 2024-03-08
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-
 - Hungarian translations.
 
 ## [2.16.10] - 2024-03-08

--- a/messages/hu.json
+++ b/messages/hu.json
@@ -1,12 +1,11 @@
 {
-  "store/topSearches": "Căutări populare",
-  "store/history": "Istoric căutări", 
-  "store/suggestions": "Sugestii",
-  "store/emptySuggestion": "Fără sugestii",
-  "store/seeMore": "Vezi toate cele {count} produse",
-  "store/suggestedProducts": "Produse pentru {term}",
+  "store/topSearches": "Legnépszerűbb keresések",
+  "store/history": "Keresési előzmények",
+  "store/suggestions": "Javaslatok",
+  "store/emptySuggestion": "Nincsenek javaslatok",
+  "store/seeMore": "Az összes {count} termék megtekintése",
+  "store/suggestedProducts": "Termékek a következőhöz: {term}",
   "store/ordinalNumber": ".",
-  "store/didYouMean": "Vrei să spui",
-  "store/searchSuggestions": "Sugestii"
+  "store/didYouMean": "Úgy értetted",
+  "store/searchSuggestions": "Javaslat"
 }
-    

--- a/messages/hu.json
+++ b/messages/hu.json
@@ -1,12 +1,12 @@
 {
-    "store/topSearches": "Căutări populare",
-    "store/history": "Istoric căutări", 
-    "store/suggestions": "Sugestii",
-    "store/emptySuggestion": "Fără sugestii",
-    "store/seeMore": "Vezi toate cele {count} produse",
-    "store/suggestedProducts": "Produse pentru {term}",
-    "store/ordinalNumber": ".",
-    "store/didYouMean": "Vrei să spui",
-    "store/searchSuggestions": "Sugestii"
-    }
+  "store/topSearches": "Căutări populare",
+  "store/history": "Istoric căutări", 
+  "store/suggestions": "Sugestii",
+  "store/emptySuggestion": "Fără sugestii",
+  "store/seeMore": "Vezi toate cele {count} produse",
+  "store/suggestedProducts": "Produse pentru {term}",
+  "store/ordinalNumber": ".",
+  "store/didYouMean": "Vrei să spui",
+  "store/searchSuggestions": "Sugestii"
+}
     

--- a/messages/hu.json
+++ b/messages/hu.json
@@ -1,0 +1,12 @@
+{
+    "store/topSearches": "Căutări populare",
+    "store/history": "Istoric căutări", 
+    "store/suggestions": "Sugestii",
+    "store/emptySuggestion": "Fără sugestii",
+    "store/seeMore": "Vezi toate cele {count} produse",
+    "store/suggestedProducts": "Produse pentru {term}",
+    "store/ordinalNumber": ".",
+    "store/didYouMean": "Vrei să spui",
+    "store/searchSuggestions": "Sugestii"
+    }
+    


### PR DESCRIPTION
It relates to the task [LOC-14426](https://vtex-dev.atlassian.net/browse/LOC-14426). Adds translations for Hungarian (`HUN` locale).

[LOC-14426]: https://vtex-dev.atlassian.net/browse/LOC-14426?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ