### PR TITLE
feat: autocomplete dataLayer events

### DIFF
--- a/react/components/Autocomplete/components/TileList/TileList.tsx
+++ b/react/components/Autocomplete/components/TileList/TileList.tsx
@@ -18,7 +18,11 @@ interface TileListProps {
   totalProducts: number
   layout: ProductLayout
   isLoading: boolean
-  onProductClick: (product: string, position: number, term: string) => void
+  onProductClick: (
+    position: number,
+    term: string,
+    productSummary: Product
+  ) => void
   onSeeAllClick: (term: string) => void
   HorizontalProductSummary?: React.ComponentType<{
     product: Product
@@ -77,14 +81,14 @@ const TileList: FC<TileListProps> = ({
                         product={productSummary}
                         placement={AUTOCOMPLETE_PLACEMENT}
                         actionOnClick={() => {
-                          onProductClick(productSummary.productId, index, term)
+                          onProductClick(index, term, productSummary)
                         }}
                       />
                     ) : (
                       <CustomListItem
                         product={productSummary}
                         onClick={() => {
-                          onProductClick(productSummary.productId, index, term)
+                          onProductClick(index, term, productSummary)
                         }}
                       />
                     )
@@ -94,7 +98,7 @@ const TileList: FC<TileListProps> = ({
                       product={productSummary}
                       placement={AUTOCOMPLETE_PLACEMENT}
                       actionOnClick={() => {
-                        onProductClick(productSummary.productId, index, term)
+                        onProductClick(index, term, productSummary)
                       }}
                     />
                   )}

--- a/react/components/Autocomplete/index.tsx
+++ b/react/components/Autocomplete/index.tsx
@@ -23,7 +23,6 @@ import { withRuntime } from '../../utils/withRuntime'
 import { decodeUrlString, encodeUrlString } from '../../utils/string-utils'
 import {
   EventType,
-  handleAutocompleteSearch,
   handleItemClick,
   handleProductClick,
   handleSeeAllClick,
@@ -310,6 +309,7 @@ class AutoComplete extends React.Component<
     const session = await getSession(this.props.runtime.rootPath)
     const shippingOptions =
       session?.map((item: Record<string, string>) => item.value) ?? []
+
     const advertisementOptions: AdvertisementOptions = {
       showSponsored: true,
       sponsoredCount: 2,
@@ -329,18 +329,6 @@ class AutoComplete extends React.Component<
       shippingOptions,
       advertisementOptions
     )
-
-    if (!queryFromHover) {
-      const { count, operator, misspelled } = result.data.productSuggestions
-
-      handleAutocompleteSearch(
-        this.props.push,
-        operator,
-        misspelled,
-        count,
-        term
-      )
-    }
 
     this.setState({
       isProductsLoading: false,
@@ -529,8 +517,12 @@ class AutoComplete extends React.Component<
           totalProducts={totalProducts || 0}
           layout={this.getProductLayout()}
           isLoading={isProductsLoading}
-          onProductClick={(id, position, term) => {
-            handleProductClick(push, runtime.page)(id, position, term)
+          onProductClick={(position, term, productSummary) => {
+            handleProductClick(push, runtime.page)(
+              position,
+              term,
+              productSummary
+            )
             this.closeModal()
           }}
           onSeeAllClick={term => {

--- a/react/utils/pixel.ts
+++ b/react/utils/pixel.ts
@@ -6,21 +6,36 @@ export enum EventType {
   TopSearchClick = 'top_search_click',
   HistoryClick = 'history_click',
   Search = 'search',
-  SeeAllClick = 'see_all_click',
+  SeeAllClick = 'see_all_products_click',
 }
 
 export function handleProductClick(push: (data: any) => void, page: string) {
-  return (productId: string, position: number, term: string) =>
+  return (position: number, term: string, productSummary: Product) => {
+    const {
+      productName,
+      brand,
+      categories,
+      sku,
+      productId,
+      productReference,
+    } = productSummary
+
     push({
       page,
-      event: EVENT_NAME,
+      event: 'productClick',
       eventType: EventType.ProductClick,
       product: {
+        productName,
+        brand,
+        categories,
+        sku,
         productId,
-        position,
+        productReference,
       },
+      position,
       term,
     })
+  }
 }
 
 export function handleItemClick(
@@ -51,36 +66,4 @@ export function handleSeeAllClick(push: (data: any) => void, page: string) {
         term,
       },
     })
-}
-
-export function handleAutocompleteSearch(
-  push: (data: any) => void,
-  operator: string,
-  misspelled: boolean,
-  count: number,
-  term: string
-) {
-  try {
-    push({
-      event: EVENT_NAME,
-      eventType: EventType.Search,
-      search: {
-        operator,
-        misspelled,
-        text: decodeURI(term),
-        match: count,
-      },
-    })
-  } catch (e) {
-    push({
-      event: EVENT_NAME,
-      eventType: EventType.Search,
-      search: {
-        operator,
-        misspelled,
-        text: term,
-        match: count,
-      },
-    })
-  }
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?

Enviar eventos de dentro do autocomplete para o dataLayer.

#### What problem is this solving?

O código atual já tinha uma estrutura inicial para enviar os eventos dentro do autocomplete, porém, esses eventos não estavam sendo enviados, como:
- Clique no termo de sugestões
- Clique no termo de histórico de busca
- Clique no produto
- etc

Com os ajustes, os seguintes eventos agora são disparados:

**top_search_click**: quando um dos termos mais buscados é clicado.
**history_click**: quando um dos termos do histórico de busca é clicado.
**search_suggestion_click**: quando é clicado em algum termo de sugestão.
**see_all_products_click**: quando é clicado na opção ver todos os produtos, se houver product-summary.
**productClick**: quando é clicado sobre algum produto.

**handleAutocompleteSearch**: descontinuei, pois não estava enviando eventos **search** e acabava sobrepondo qualquer um dos eventos acima, enviando os dados vazios.

#### How should this be manually tested?

**top_search_click**: clique no input da barra de busca e em seguida clique em um dos termos mais buscados.
**history_click**:  clique no input da barra de busca e em seguida clique em dos termos que você já pesquisou e que está no histórico de busca,
**search_suggestion_click**: clique no input da barra de busca e em seguida digite algum termo. Algumas sugestões de termos irão aparecer, clique em alguma delas.
**see_all_products_click**: clique no input da barra de busca e em seguida digite algum termo. Na shelf, clique em ver todos os produtos (caso tenha). 
**productClick**: clique no input da barra de busca e em seguida digite algum termo. Na shelf, clique sobre algum produto (caso tenha).

Essa PR também tem dependências de outras PRs:


#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
