### PR TITLE
feature/ add a validation when render items in ItemLIst and items.len…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- verification in component for acessibility validation
+
 ## [2.18.2] - 2025-01-22
 
 ## [2.18.1] - 2024-09-02

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-### Added
-- verification in component for acessibility validation
+### Changed
+- Only showing list for `ItemList` if it has items available
 
 ## [2.18.2] - 2025-01-22
 

--- a/react/components/Autocomplete/components/ItemList/ItemList.tsx
+++ b/react/components/Autocomplete/components/ItemList/ItemList.tsx
@@ -67,51 +67,54 @@ export class ItemList extends React.Component<ItemListProps> {
             {this.props.title}
           </p>
         ) : null}
-        <ol className={stylesCss.itemListList}>
-          {this.props.items.map((item, index) => {
-            return (
-              <li
-                key={item.value}
-                className={`${stylesCss.itemListItem}`}
-                onMouseOver={e => this.handleMouseOver(e, item)}
-                onFocus={e => this.handleMouseOver(e, item)}
-                onMouseOut={() => this.handleMouseOut()}
-                onBlur={() => this.handleMouseOut()}
-              >
-                <Link
-                  page={this.props.customPage ?? 'store.search'}
-                  params={{
-                    term: item.value,
-                  }}
-                  query={`map=ft&_q=${item.value}`}
-                  onClick={() => this.props.onItemClick(item.value, index)}
-                  className={stylesCss.itemListLink}
+        {this.props.items.length > 0 && (
+          <ol className={stylesCss.itemListList}>
+            {this.props.items.map((item, index) => {
+              return (
+                <li
+                  key={item.value}
+                  className={`${stylesCss.itemListItem}`}
+                  onMouseOver={e => this.handleMouseOver(e, item)}
+                  onFocus={e => this.handleMouseOver(e, item)}
+                  onMouseOut={() => this.handleMouseOut()}
+                  onBlur={() => this.handleMouseOut()}
                 >
-                  {item.icon ? (
-                    <span className={stylesCss.itemListIcon}>{item.icon}</span>
-                  ) : null}
+                  <Link
+                    page={this.props.customPage ?? 'store.search'}
+                    params={{
+                      term: item.value,
+                    }}
+                    query={`map=ft&_q=${item.value}`}
+                    onClick={() => this.props.onItemClick(item.value, index)}
+                    className={stylesCss.itemListLink}
+                  >
+                    {item.icon ? (
+                      <span className={stylesCss.itemListIcon}>{item.icon}</span>
+                    ) : null}
 
-                  {item.prefix ? (
-                    <span className={stylesCss.itemListPrefix}>
-                      {item.prefix}
+                    {item.prefix ? (
+                      <span className={stylesCss.itemListPrefix}>
+                        {item.prefix}
+                      </span>
+                    ) : null}
+
+                    <span className={`${stylesCss.itemListLinkTitle} c-on-base`}>
+                      {item.label}
                     </span>
-                  ) : null}
+                  </Link>
+                  <Attribute
+                    item={item}
+                    onMouseOver={this.handleMouseOver}
+                    onMouseOut={this.handleMouseOut}
+                    closeModal={this.props.closeModal}
+                    onItemClick={this.props.onItemClick}
+                  />
+                </li>
+              )
+            })}
+          </ol>
+        )}
 
-                  <span className={`${stylesCss.itemListLinkTitle} c-on-base`}>
-                    {item.label}
-                  </span>
-                </Link>
-                <Attribute
-                  item={item}
-                  onMouseOver={this.handleMouseOver}
-                  onMouseOut={this.handleMouseOut}
-                  closeModal={this.props.closeModal}
-                  onItemClick={this.props.onItemClick}
-                />
-              </li>
-            )
-          })}
-        </ol>
       </article>
     )
   }


### PR DESCRIPTION
…bility applications and automated testing

What is the purpose of this pull request?
I inserted a definition in the component, this modification is for accessibility app

What problem is this solving?
acessibility problems


Descrição detalhada de como a correção resolve um problema de acessibilidade (a11y).

durante os testes automatizados, foi captado que o componente exibia umas das estrutura de lista, porem essa estrutura não possuía nenhum tipo de item filho, e isso se tornou invalido para os testes, então apenas validei a existência dos valores para que esse componente que contem a lista fosse exibido somente quando a lista não fosse vazia, conclusão o componente “<ol></ol>” não será exibido vazio com essa validação de existência dos itens.

after :
![image](https://github.com/user-attachments/assets/ebbeadef-0d8f-4000-9c81-cc7fadc34d9a)


Before
![image](https://github.com/user-attachments/assets/9311f8d4-1a97-46f8-b890-6114a5a383d7)


Instruções de como testar a correção.

irei disponibilizar o link do workspace, para testar buscar pela classe “itemListTitle” usando o devtools nos links eu irei lhe enviar, vou anexar dois links um onde o componente vazio e escondido e outro em que ele aparece com os conteúdos necessários para não ser um erro de acessibilidade.

- link com o item vazio não exibido : [https://vtexpr206--hmartus.myvtex.com/mango ice cream?_q=mango ice cream&map=ft&updateRegionalization=false&__bindingAddress=www.hmart.com/](https://vtexpr206--hmartus.myvtex.com/mango%20ice%20cream?_q=mango%20ice%20cream&map=ft&updateRegionalization=false&__bindingAddress=www.hmart.com/)

- link com o componente preenchido exibido : https://vtexpr206--hmartus.myvtex.com/rice---grain?__bindingAddress=www.hmart.com/&page=3

Atualização do changelog com as alterações feitas.

### Added
- verification in component for acessibility validation