### PR TITLE
feat(autocomplete): add searchId to state and TileList component for …

### DIFF
--- a/react/components/Autocomplete/components/TileList/TileList.tsx
+++ b/react/components/Autocomplete/components/TileList/TileList.tsx
@@ -25,6 +25,7 @@ interface TileListProps {
     placement: string
     actionOnClick: () => void
   }>
+  searchId: string
 }
 
 const AUTOCOMPLETE_PLACEMENT = 'autocomplete'
@@ -41,13 +42,18 @@ const TileList: FC<TileListProps> = ({
   onSeeAllClick,
   HorizontalProductSummary,
   customPage,
+  searchId
 }) => {
   if (products.length === 0 && !isLoading) {
     return null
   }
 
   return (
-    <section className={styles.tileList}>
+    <section
+      className={styles.tileList}
+      data-af-onimpression={searchId ? true : undefined}
+      data-af-search-id={searchId}
+    >
       {showTitle ? (
         <p className={`${styles.tileListTitle} c-on-base`}>{title}</p>
       ) : null}
@@ -70,7 +76,14 @@ const TileList: FC<TileListProps> = ({
               )
 
               return (
-                <li key={product.productId} className={styles.tileListItem}>
+                <li
+                  key={product.productId}
+                  className={styles.tileListItem}
+                  data-af-onclick={searchId && product.productId ? true : undefined}
+                  data-af-search-id={searchId}
+                  data-af-product-position={index + 1}
+                  data-af-product-id={product.productId}
+                >
                   {layout === ProductLayout.Horizontal ? (
                     HorizontalProductSummary ? (
                       <HorizontalProductSummary

--- a/react/components/Autocomplete/index.tsx
+++ b/react/components/Autocomplete/index.tsx
@@ -93,6 +93,7 @@ interface AutoCompleteState {
   dynamicTerm: string
   isProductsLoading: boolean
   currentHeightWhenOpen: number
+  searchId: string
 }
 
 const { ProductListProvider } = ProductListContext
@@ -115,6 +116,7 @@ class AutoComplete extends React.Component<
     dynamicTerm: '',
     isProductsLoading: false,
     currentHeightWhenOpen: 0,
+    searchId: ''
   }
 
   constructor(props: WithApolloClient<AutoCompleteProps>) {
@@ -356,6 +358,7 @@ class AutoComplete extends React.Component<
     this.setState({
       products,
       totalProducts: productSuggestions.count,
+      searchId: productSuggestions.searchId || ''
     })
   }
 
@@ -507,7 +510,7 @@ class AutoComplete extends React.Component<
   }
 
   contentWhenQueryIsNotEmpty() {
-    const { products, totalProducts, isProductsLoading } = this.state
+    const { products, totalProducts, isProductsLoading, searchId } = this.state
     const { hideTitles, push, runtime, inputValue } = this.props
     const inputValueEncoded = encodeUrlString(inputValue)
 
@@ -538,6 +541,7 @@ class AutoComplete extends React.Component<
             this.closeModal()
           }}
           HorizontalProductSummary={this.props.HorizontalProductSummary}
+          searchId={searchId}
         />
       </>
     )

--- a/react/utils/biggy-client.ts
+++ b/react/utils/biggy-client.ts
@@ -95,6 +95,7 @@ interface IProductsOutput {
   count: number
   misspelled: boolean
   operator: string
+  searchId: string
 }
 
 interface ISuggestionQueryResponseSearch {


### PR DESCRIPTION
This pull request introduces support for tracking and passing a `searchId` throughout the autocomplete product suggestion workflow. This enables the frontend to annotate rendered product lists and items with search-related metadata, which can be used for analytics or tracking user interactions with search results.

**Search ID propagation and analytics instrumentation:**

* Added a `searchId` property to the product suggestion output (`IProductsOutput` in `react/utils/biggy-client.ts`) and to the autocomplete state (`AutoCompleteState` in `react/components/Autocomplete/index.tsx`). This ensures the search identifier is available wherever product suggestions are handled. [[1]](diffhunk://#diff-622eb2cd36275257fe74dba7f83086a42ed3741a0072a190c00b327940883d2aR98) [[2]](diffhunk://#diff-f546df16b50e51b6fae2579ba21741c18c7cd0e5e69b24a82a7c5031c0a608f6R96)
* Updated the autocomplete component to store and propagate the `searchId` from product suggestions into its state, and to pass it down to the `TileList` component. [[1]](diffhunk://#diff-f546df16b50e51b6fae2579ba21741c18c7cd0e5e69b24a82a7c5031c0a608f6R361) [[2]](diffhunk://#diff-f546df16b50e51b6fae2579ba21741c18c7cd0e5e69b24a82a7c5031c0a608f6L510-R513) [[3]](diffhunk://#diff-f546df16b50e51b6fae2579ba21741c18c7cd0e5e69b24a82a7c5031c0a608f6R544) [[4]](diffhunk://#diff-f546df16b50e51b6fae2579ba21741c18c7cd0e5e69b24a82a7c5031c0a608f6R119)
* Enhanced the `TileList` component to accept a `searchId` prop and render it as data attributes (`data-af-search-id`, `data-af-onimpression`, `data-af-onclick`, etc.) on product list and item elements. This provides detailed instrumentation for analytics purposes. [[1]](diffhunk://#diff-6b0a2438c824db3f70acc774639629993b4880f20f63c031a3d41237a4e723dcR28) [[2]](diffhunk://#diff-6b0a2438c824db3f70acc774639629993b4880f20f63c031a3d41237a4e723dcR45-R56) [[3]](diffhunk://#diff-6b0a2438c824db3f70acc774639629993b4880f20f63c031a3d41237a4e723dcL73-R86)