### PR TITLE
feat(biggy-client): add origin property to request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Add origin to autocomplete request
+
 ## [2.18.4] - 2025-07-28
 
 ## Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [2.18.5] - 2025-09-18
+### Added
+
+- Add origin to autocomplete request
 
 ## [2.18.4] - 2025-07-28
 

--- a/react/utils/biggy-client.ts
+++ b/react/utils/biggy-client.ts
@@ -59,6 +59,7 @@ export default class BiggyClient {
         count,
         shippingOptions,
         variant: getCookie('sp-variant'),
+        origin: 'autocomplete'
       },
       fetchPolicy: 'network-only',
     })


### PR DESCRIPTION
This pull request introduces a small but important change to the autocomplete feature by adding an `origin` field to the autocomplete request. This will help identify the source of the request as coming from autocomplete, which can be useful for analytics, debugging, or routing purposes.

- **Autocomplete request enhancement:**
  - Added an `origin: 'autocomplete'` field to the request payload in `BiggyClient` to specify the source of the request.
  - Documented the addition of the origin field in the `CHANGELOG.md`.